### PR TITLE
Readme update: The call bootstrap-responsive-tabs() didn't work ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bootstrap Responsive Tabs is available on [Bower](https://github.com/bower/bower
 ## Usage
 The JS:
 ```
-$(".js-tabs-example").bootstrap-responsive-tabs({
+$(".js-tabs-example").bootstrapResponsiveTabs({
     minTabWidth: "100",
     maxTabWidth: "200"
 });


### PR DESCRIPTION
... but bootstrapResponsiveTabs() did.
